### PR TITLE
Just alloc 64k ops right away, avoids the reserves.

### DIFF
--- a/src/bjit.h
+++ b/src/bjit.h
@@ -204,6 +204,9 @@ namespace bjit
         //
         Proc(unsigned allocBytes, const char * args)
         {
+            // reserve space for maximum number of ops
+            // NOTE: opt-ra and opt-fold assume we don't realloc
+            ops.reserve(noVal);
             currentBlock = newLabel();
             emitLabel(currentBlock);
 

--- a/src/opt-fold.cpp
+++ b/src/opt-fold.cpp
@@ -105,9 +105,6 @@ bool Proc::opt_fold()
         {
             for(auto bc : blocks[b].code)
             {
-                // protect refs: really only need +1 but whatever
-                ops.reserve(ops.size() + 10);
-                
                 auto & op = ops[bc];
 
                 if(op.opcode == ops::nop)

--- a/src/opt-ra.cpp
+++ b/src/opt-ra.cpp
@@ -139,9 +139,6 @@ void Proc::allocRegs()
         
         for(int c = 0; c < blocks[b].code.size(); ++c)
         {
-            // reserve some excess, so we can keep reference
-            // should be max ~5, but alloc safe
-            ops.reserve(ops.size() + 20);
             auto & op = ops[blocks[b].code[c]];
 
             uint16_t lastOp = codeOut.size() ? codeOut.back() : 0xffff;


### PR DESCRIPTION
If we have a max limit of 64k ops, then we can just as well allocate worst-case.