### PR TITLE
Implement sinking and don't hoist INTO loops.

### DIFF
--- a/src/bjit.h
+++ b/src/bjit.h
@@ -243,7 +243,7 @@ namespace bjit
         {
             // do DCE first, then fold
             // repeat until neither does progress
-            do opt_dce(); while(opt_fold());
+            do opt_dce(); while(opt_fold() || opt_sink());
         }
 
         void compile(std::vector<uint8_t> & bytes)
@@ -573,7 +573,7 @@ namespace bjit
         bool opt_fold();
 
         // opt-sink.cpp
-        void opt_sink();
+        bool opt_sink();
 
         // opt-dce.cpp
         void opt_dce();

--- a/src/opt-dce.cpp
+++ b/src/opt-dce.cpp
@@ -503,7 +503,7 @@ void Proc::livescan()
     for(auto & op : ops)
     {
         // NOTE: nUse aliases on labels
-        if(op.opcode > ops::jmp) op.nUse = 0;
+        if(op.hasOutput()) op.nUse = 0;
     }
 
     for(auto & b : live) blocks[b].livein.clear();

--- a/src/opt-fold.cpp
+++ b/src/opt-fold.cpp
@@ -1205,6 +1205,14 @@ bool Proc::opt_fold()
                                 
                             mblock = blocks[mblock].idom;
                         }
+
+                        // don't hoist if the actual target branches
+                        // we allow CSE in this case, but don't pull single
+                        // operations outside loops into them
+                        if(ops[blocks[mblock].code.back()].opcode < ops::jmp)
+                        {
+                            mblock = b;
+                        }
                         
                         // if mblock is the current block, then we can't move
                         if(mblock != b)

--- a/src/opt-ra.cpp
+++ b/src/opt-ra.cpp
@@ -884,9 +884,11 @@ void Proc::findSCC()
         // reserve all SCCs of live-in registers
         for(auto in : b.livein)
         {
-            // since we're doing live-scan live any live-in
+            // since we're doing live-scan order any live-in
             // variables should already have their SCC allocated
-            assert(ops[in].scc != noSCC);
+            // unless it's a loop-thru PHI which we fix below
+            assert(ops[in].scc != noSCC
+            || (ops[in].opcode == ops::phi && ops[in].block == bi));
             // this is just a sanity check
             assert(ops[in].scc < sccUsed.size());
             sccUsed[ops[in].scc] = true;

--- a/src/opt-sink.cpp
+++ b/src/opt-sink.cpp
@@ -1,0 +1,166 @@
+
+#include "bjit.h"
+
+using namespace bjit;
+
+bool Proc::opt_sink()
+{
+    livescan(); // need live-out information
+
+    printf(" SINK");
+
+    //debug();
+
+    // collect moved ops into tmp (in reverse)
+    // so that we can merge them all together
+    std::vector<uint16_t>   tmp0, tmp1;
+
+    // one pass should be enough 'cos DFS
+    bool progress = false;
+    for(auto b : live)
+    {
+        // find local-only uses
+        findUsesBlock(b, true);
+
+        auto & jmp = ops[blocks[b].code.back()];
+
+        // is this a return block?
+        if(jmp.opcode > ops::jmp) continue;
+
+        // is this a straight jmp?
+        if(jmp.opcode == ops::jmp)
+        {
+            // if we don't dominate the block, then bail out
+            if(blocks[jmp.label[0]].idom != b) continue;
+        }
+
+        tmp0.clear();
+        tmp1.clear();
+
+        // loop code backwards
+        for(int c = blocks[b].code.size(); c--;)
+        {
+            auto op = ops[blocks[b].code[c]];
+
+            // is this something we're allowed to move?
+            // does it have local uses?
+            if(!op.canCSE() || op.nUse) continue;
+
+            // it must be live-out in at least one block
+            bool live0 = false, live1 = false;
+
+            for(auto l : blocks[jmp.label[0]].livein)
+            {
+                if(op.index != l) continue;
+                live0 = true;
+                continue;
+            }
+
+            if(jmp.opcode < ops::jmp)
+                for(auto l : blocks[jmp.label[1]].livein)
+            {
+                if(op.index != l) continue;
+                live0 = true;
+                continue;
+            }
+
+            // don't move if live (or dead) in both branches
+            if(live0 == live1) continue;
+
+            // do not move into blocks that merge paths
+            // this prevents us from sinking loop invariants
+            // back into the loop, which would be silly
+            if(blocks[jmp.label[live0?0:1]].comeFrom.size() > 1) continue;
+
+            // pick the block where this is live
+            (live0 ? tmp0 : tmp1).push_back(op.index);
+            blocks[b].code[c] = noVal;  // dead at original site
+
+            // see if we should be moving inputs too?
+            for(int k = 0; k < op.nInputs(); ++k)
+            {
+                // if this was last use, for something in this block
+                // then mark it as livein for the block where we moved
+                if(ops[op.in[k]].block == b && !--ops[op.in[k]].nUse)
+                {
+                    (live0 ? blocks[jmp.label[0]] : blocks[jmp.label[1]])
+                        .livein.push_back(op.in[k]);
+                }
+            }
+        }
+
+        // did we move anything?
+        if(tmp0.size())
+        {
+            progress = true;
+            
+            // skip any ops that must be in the beginning
+            // really just phis, but try to be future-proof
+            int insertAt = 0;
+            int tBlock = jmp.label[0];
+            while(insertAt < blocks[tBlock].code.size())
+            {
+                if(ops[blocks[tBlock].code[insertAt]].canMove()) break;
+                ++insertAt;
+            }
+
+            // make room and move original ops back
+            auto & tcode = blocks[tBlock].code;
+            tcode.resize(tcode.size() + tmp0.size());
+            for(int i = tcode.size(); i-- > insertAt;)
+            {
+                tcode[i] = tcode[i-tmp0.size()];
+            }
+            
+            //printf("Moving B%d -> B%d:\n", b, jmp.label[0]);
+            
+            // then work merge tmp which needs to be reversed
+            for(int i = insertAt; tmp0.size(); i++)
+            {
+                //debugOp(tmp0.back());
+                tcode[i] = tmp0.back(); tmp0.pop_back();
+                ops[tcode[i]].block = tBlock;
+            }
+        }
+        
+        if(tmp1.size())
+        {
+            progress = true;
+            
+            assert(jmp.opcode < ops::jmp);
+            
+            // skip any ops that must be in the beginning
+            // really just phis, but try to be future-proof
+            int insertAt = 0;
+            int tBlock = jmp.label[1];
+            while(insertAt < blocks[tBlock].code.size())
+            {
+                if(ops[blocks[tBlock].code[insertAt]].canMove()) break;
+                ++insertAt;
+            }
+            
+            // make room and move original ops back
+            auto & tcode = blocks[tBlock].code;
+            tcode.resize(tcode.size() + tmp1.size());
+            for(int i = tcode.size(); i-- > insertAt;)
+            {
+                tcode[i] = tcode[i-tmp1.size()];
+            }
+
+            //printf("Moving B%d -> B%d:\n", b, jmp.label[1]);
+            
+            // then work merge tmp which needs to be reversed
+            for(int i = insertAt; tmp1.size(); i++)
+            {
+                //debugOp(tmp1.back());
+                
+                tcode[i] = tmp1.back(); tmp1.pop_back();
+                ops[tcode[i]].block = tBlock;
+            }
+        }
+    }
+
+    //debug();
+    
+    return progress;
+}


### PR DESCRIPTION
We should now be able to move all redundant stuff out of simple loops, even if it only becomes redundant after folding.