### PR TITLE
opt_jump_be test-case and make it do the right thing

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -15,8 +15,8 @@ bin/test_callp
 bin/test_calln
 
 bin/test_fib
-
 bin/test_call_stub
+bin/test_loop   # this tries to confuse opt_jump_be
 
 cat << END | bin/bjit
     x := 0/0; y := x/1u;

--- a/src/opt-ra.cpp
+++ b/src/opt-ra.cpp
@@ -1153,15 +1153,7 @@ void Proc::findSCC()
         {
             if(blocks[ops[c].label[k]].comeFrom.size() < 2) continue;
 
-            auto shuffle = breakEdge(b, ops[c].label[k]);
-            
-            for(auto & a : blocks[ops[c].label[k]].args)
-            for(auto & s : a.alts)
-            {
-                if(s.src == b) s.src = shuffle;
-            }
-
-            ops[c].label[k] = shuffle;
+            ops[c].label[k] = breakEdge(b, ops[c].label[k]);
         }
     }
 

--- a/tests/test_loop.cpp
+++ b/tests/test_loop.cpp
@@ -1,0 +1,72 @@
+
+#include "bjit.h"
+
+int proc(int x, int y)
+{
+    int i = 0;
+
+    while(true)
+    {
+        if((++i) >= x) break;
+        if((++i) >= y) break;
+
+        ++i;
+    };
+
+    return i;
+}
+
+int main()
+{
+
+    bjit::Module    module;
+    {
+        bjit::Proc  pr(0, "ii");
+
+        pr.env.push_back(pr.lci(0));
+
+        auto la = pr.newLabel();
+        auto lb = pr.newLabel();
+        auto lc = pr.newLabel();
+        auto le = pr.newLabel();
+
+        pr.jmp(la);
+
+        pr.emitLabel(la);
+        pr.env[2] = pr.iadd(pr.env[2], pr.lci(1));
+        pr.jnz(pr.ige(pr.env[2], pr.env[0]), le, lb);
+        
+        pr.emitLabel(lb);
+        pr.env[2] = pr.iadd(pr.env[2], pr.lci(1));
+        pr.jnz(pr.ige(pr.env[2], pr.env[1]), le, lc);
+        
+        pr.emitLabel(lc);
+        pr.env[2] = pr.iadd(pr.env[2], pr.lci(1));
+        pr.jmp(la);
+
+        pr.emitLabel(le);
+        pr.iret(pr.env[2]);
+
+        pr.debug();
+        module.compile(pr);
+    }
+    auto & codeOut = module.getBytes();
+    FILE * f = fopen("out.bin", "wb");
+    fwrite(codeOut.data(), 1, codeOut.size(), f);
+    fclose(f);
+    printf(" - Wrote out.bin\n");
+    BJIT_ASSERT(module.load());
+
+    for(int i = 0; i < 4; ++i)
+    {
+        auto h = bjit::hash64(i+1);
+        int x = h&0xff;
+        int y = (h>>8)&0xff;
+        int z = proc(x,y);
+        int zjit = module.getPointer<int(int,int)>(0)(x,y);
+        printf("proc(%d,%d) = %d (jit says %d)\n", x, y, z, zjit);
+        BJIT_ASSERT(z == zjit);
+    }
+
+    return 0;
+}

--- a/tests/test_loop.cpp
+++ b/tests/test_loop.cpp
@@ -57,7 +57,7 @@ int main()
     printf(" - Wrote out.bin\n");
     BJIT_ASSERT(module.load());
 
-    for(int i = 0; i < 4; ++i)
+    for(int i = 0; i < 16; ++i)
     {
         auto h = bjit::hash64(i+1);
         int x = h&0xff;


### PR DESCRIPTION
This PR makes opt_jump_be rely on dominator relationships when adding phis, rather than assuming that they only need to be added in the branch blocks. There might be some corner cases with merging paths that still need fixing (and these should hopefully assert now), but I need to write more torture tests to try to actuall reproduce the problem.

In any case, this PR should fix all the common cases properly.