### PR TITLE
RA now tries to move phi-spills to sources instead

### DIFF
--- a/src/bjit-impl.h
+++ b/src/bjit-impl.h
@@ -90,7 +90,11 @@ namespace bjit
             struct {
                 Type    type    : 4;    // see above, packed into flags
                 bool    spill   : 1;
-                bool    no_opt  : 1;    // don't unroll or hoist further
+                
+                // no_opt on jumps means "don't try to unroll this further"
+                // no_opt on regular ops means "don't hoist this further"
+                // no_opt on phis in RA means "don't try to spill sources"
+                bool    no_opt  : 1;
             } flags = {};
     
     

--- a/src/sanity.cpp
+++ b/src/sanity.cpp
@@ -16,6 +16,8 @@ void Proc::sanity()
 
     rebuild_livein();
     opt_dce();  // do another round to get use counts?
+    rebuild_dom();
+    
     debug();
     
     for(auto & b : live)


### PR DESCRIPTION
This avoids most of the useless respilling in loops. 