### PR TITLE
opt-ra: treat 2-reg and 3-reg ISAs differently

### DIFF
--- a/src/arch-arm64.h
+++ b/src/arch-arm64.h
@@ -3,6 +3,8 @@
 
 namespace bjit
 {
+    // this is a hint for opt-ra
+    static const bool arch_explicit_output_regs = true;
 
     // we use this for types, etc
     typedef uint64_t    RegMask;

--- a/src/arch-x64.h
+++ b/src/arch-x64.h
@@ -63,6 +63,8 @@ EDI/DI/BH/MM7/XMM7    111    C7   CF   D7   DF   E7   EF   F7   FF
 
 namespace bjit
 {
+    // this is a hint for opt-ra
+    static const bool arch_explicit_output_regs = false;
 
     // we use this for types, etc
     typedef uint64_t    RegMask;

--- a/src/opt-ra.cpp
+++ b/src/opt-ra.cpp
@@ -600,7 +600,8 @@ void Proc::allocRegs(bool unsafeOpt)
                     if(regstate[ops[op.in[i]].reg] == op.in[i])
                     {
                         regstate[ops[op.in[i]].reg] = noVal;
-                        if(!i) prefer = ops[op.in[i]].reg;
+                        if(!i && !arch_explicit_output_regs)
+                            prefer = ops[op.in[i]].reg;
                     }
                 }
             }
@@ -747,7 +748,9 @@ void Proc::allocRegs(bool unsafeOpt)
             RegMask mask = op.regsOut();
 
             // try to mask second operand if possible
-            if(op.nInputs()>1 && op.in[0] != op.in[1]
+            // if the ISA globs the first register
+            if(!arch_explicit_output_regs
+            && op.nInputs()>1 && op.in[0] != op.in[1]
             && (mask &~R2Mask(ops[op.in[1]].reg)))
                 mask &=~R2Mask(ops[op.in[1]].reg);
             


### PR DESCRIPTION
On x86 opt-ra tries to take into account that the native ISA overwrites the first operand with the result, but on ARM this results in pointless shuffles as the ISA takes a separate destination register. The patch adds an architecture flag which so opt-ra knows whether it's allocating for 2-regs or 3-reg ISA.