### PR TITLE
arm64: skip stackframe when it's not needed

### DIFF
--- a/src/arch-arm64-ops.cpp
+++ b/src/arch-arm64-ops.cpp
@@ -194,7 +194,7 @@ RegMask Op::regsLost()
 
         case ops::icalln: case ops::fcalln: case ops::dcalln:
         case ops::icallp: case ops::fcallp: case ops::dcallp:
-            return regs::caller_saved;
+            return regs::caller_saved | R2Mask(regs::lr);
 
         default: return 0;
     }

--- a/src/opt-ra.cpp
+++ b/src/opt-ra.cpp
@@ -607,7 +607,7 @@ void Proc::allocRegs(bool unsafeOpt)
             }
 
             // clobbers - could try to save, but whatever
-            RegMask lost = op.regsLost();
+            RegMask lost = op.regsLost(); usedRegs |= lost;
             if(lost)
             {
                 RegMask notlost = ~lost;


### PR DESCRIPTION
If the function is a leaf (or only tail-calls) and doesn't need to save anything on stack, then don't bother building a stack frame at all, since it's not like we play nice with debuggers anyway.