### PR TITLE
opt-ra: always prefer input reg for renames

### DIFF
--- a/src/opt-ra.cpp
+++ b/src/opt-ra.cpp
@@ -600,7 +600,8 @@ void Proc::allocRegs(bool unsafeOpt)
                     if(regstate[ops[op.in[i]].reg] == op.in[i])
                     {
                         regstate[ops[op.in[i]].reg] = noVal;
-                        if(!i && !arch_explicit_output_regs)
+                        if(op.opcode == ops::rename
+                        || (!i && !arch_explicit_output_regs))
                             prefer = ops[op.in[i]].reg;
                     }
                 }


### PR DESCRIPTION
Even on 3-reg architectures, renames still should prefer input reg, so they ideally become NOPs and get removed.