### PR TITLE
Use IVs in opt-ra and improve threading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,11 @@ else
     MAKEDIR := mkdir -p
     CLEANALL := rm -rf $(BJIT_BUILDDIR) $(BJIT_BINDIR)
     BJIT_LINKLIB ?= libtool -static -o $(LIBRARY)
+
+    ifeq ($(shell uname),Darwin)
+        BJIT_LINKLIB += -no_warning_for_no_symbols
+    endif
+    
 endif
 
 # this works with clang on Windows too

--- a/src/arch-arm64-emit.cpp
+++ b/src/arch-arm64-emit.cpp
@@ -149,15 +149,47 @@ void Proc::arch_emit(std::vector<uint8_t> & out)
     todo.push_back(0);
     blocks[0].flags.codeDone = true;
 
-    // this checks if todo-stack top ends in
+    auto threadJump = [&](unsigned label) -> unsigned
+    {
+        // otherwise see if we can thread
+        bool progress = true;
+        while(progress)
+        {
+            progress = false;
+            for(auto c : blocks[label].code)
+            {
+                // if this is a simple phi, skip
+                if(ops[c].opcode == ops::phi && !ops[c].flags.spill)
+                    continue;
+    
+                if(ops[c].opcode == ops::jmp)
+                {
+                    label = ops[c].label[0];
+                    progress = true;
+                }
+                break;
+            }
+        }
+
+        return label;
+    };
+
+    // schedules a block and checks if it ends in
     // unconditional jump to unscheduled block
     // we put such blocks below stack top
     //
     // this should place one shuffle just before it's target block
-    auto scheduleThreading = [&]()
+    auto scheduleBlock = [&](unsigned label)
     {
-        if(!todo.size()) return;
+        label = threadJump(label);
         
+        if(blocks[label].flags.codeDone) return;
+
+        blocks[label].flags.codeDone = true;
+        todo.push_back(label);
+        
+        if(!todo.size()) return;
+
         auto & b = blocks[todo.back()];
         auto & j = ops[b.code.back()];
         if(j.opcode == ops::jmp && !blocks[j.label[0]].flags.codeDone)
@@ -174,6 +206,9 @@ void Proc::arch_emit(std::vector<uint8_t> & out)
         // if we'll emit this block next
         // there's no need to generate jmp
         if(todo.size() && todo.back() == label) return;
+
+        label = threadJump(label);
+        
         if(!blocks[label].flags.codeDone)
         {
             blocks[label].flags.codeDone = true;
@@ -281,13 +316,8 @@ void Proc::arch_emit(std::vector<uint8_t> & out)
                 a64.emit32(0x54000000
                     | _CC(i.opcode)
                     | ((0x7ffff & -(out.size()>>2))<<5));
-                
-                if(!blocks[i.label[0]].flags.codeDone)
-                {
-                    blocks[i.label[0]].flags.codeDone = true;
-                    todo.push_back(i.label[0]);
-                    scheduleThreading();
-                }
+
+                scheduleBlock(i.label[0]);
                 doJump(i.label[1]);
                 break;
 
@@ -312,13 +342,7 @@ void Proc::arch_emit(std::vector<uint8_t> & out)
                     | REG(ops[i.in[0]].reg)
                     | ((0x7ffff & -(out.size()>>2))<<5));
             #endif
-                
-                if(!blocks[i.label[0]].flags.codeDone)
-                {
-                    blocks[i.label[0]].flags.codeDone = true;
-                    todo.push_back(i.label[0]);
-                    scheduleThreading();
-                }
+                scheduleBlock(i.label[0]);
                 doJump(i.label[1]);
                 break;
                 
@@ -354,13 +378,8 @@ void Proc::arch_emit(std::vector<uint8_t> & out)
                 a64.emit32(0x54000000
                     | _CC(i.opcode+ops::jilt-ops::jiltI)
                     | ((0x7ffff & -(out.size()>>2))<<5));
-                
-                if(!blocks[i.label[0]].flags.codeDone)
-                {
-                    blocks[i.label[0]].flags.codeDone = true;
-                    todo.push_back(i.label[0]);
-                    scheduleThreading();
-                }
+
+                scheduleBlock(i.label[0]);
                 doJump(i.label[1]);
                 break;
                 
@@ -378,12 +397,7 @@ void Proc::arch_emit(std::vector<uint8_t> & out)
                     | _CC(i.opcode)
                     | ((0x7ffff & -(out.size()>>2))<<5));
                 
-                if(!blocks[i.label[0]].flags.codeDone)
-                {
-                    blocks[i.label[0]].flags.codeDone = true;
-                    todo.push_back(i.label[0]);
-                    scheduleThreading();
-                }
+                scheduleBlock(i.label[0]);
                 doJump(i.label[1]);
                 break;
                 
@@ -401,12 +415,7 @@ void Proc::arch_emit(std::vector<uint8_t> & out)
                     | _CC(i.opcode)
                     | ((0x7ffff & -(out.size()>>2))<<5));
                 
-                if(!blocks[i.label[0]].flags.codeDone)
-                {
-                    blocks[i.label[0]].flags.codeDone = true;
-                    todo.push_back(i.label[0]);
-                    scheduleThreading();
-                }
+                scheduleBlock(i.label[0]);
                 doJump(i.label[1]);
                 break;
                 

--- a/src/arch-arm64-emit.cpp
+++ b/src/arch-arm64-emit.cpp
@@ -184,7 +184,6 @@ void Proc::arch_emit(std::vector<uint8_t> & out)
             a64.addReloc(label);
             a64.emit32(0x14000000 | (0x3ffffff & -(out.size() >> 2)));
         }
-        scheduleThreading();
     };
 
     auto emitOp = [&](Op & i)

--- a/src/arch-x64-emit.cpp
+++ b/src/arch-x64-emit.cpp
@@ -162,7 +162,6 @@ void Proc::arch_emit(std::vector<uint8_t> & out)
             a64.addReloc(label);
             a64.emit32(-4-out.size());
         }
-        scheduleThreading();
     };
 
     auto emitOp = [&](Op & i)

--- a/src/bjit-impl.h
+++ b/src/bjit-impl.h
@@ -56,7 +56,12 @@ namespace bjit
 
                         // this must be signed!
                         int32_t     imm32;
-                        uint32_t    phiIndex;
+
+                        struct
+                        {
+                            uint16_t    phiIndex;
+                            uint16_t    iv;
+                        };
                         
                         struct  // used by arguments
                         {

--- a/src/bjit.h
+++ b/src/bjit.h
@@ -119,6 +119,7 @@ namespace bjit
                 auto phi = addOp(ops::phi, ops[env[i].index].flags.type, label);
                 blocks[label].args[i].phiop = phi;
                 ops[phi].phiIndex = i;
+                ops[phi].iv = noVal;
             }
             
             return Label{label};
@@ -456,7 +457,7 @@ namespace bjit
                 if(repeat) opt_dce();
 
                 // always check jumps, this is relatively cheap
-                if(opt_jump()) { repeat = true; opt_dce(); }
+                if(opt_jump()) { repeat = true; }
             }
 
             // this should not currently enable further optimization

--- a/src/bjit.h
+++ b/src/bjit.h
@@ -649,6 +649,7 @@ namespace bjit
         // opt-jump.cpp
         bool opt_jump_be(uint16_t b);
         bool opt_jump();
+        void find_ivs();
 
         // opt-cse.cpp
         void rebuild_memtags(bool unsafeOpt);

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -106,6 +106,8 @@ void bjit::Proc::debugOp(uint16_t iop) const
             else 
                 BJIT_LOG(" L%d:[----]:%04x", a.src, a.val);
         }
+
+        if(op.iv != noVal) BJIT_LOG(" IV:%04x", op.iv);
     }
 
     if(op.opcode == ops::iarg || op.opcode == ops::farg || op.opcode == ops::darg)

--- a/src/opt-cse.cpp
+++ b/src/opt-cse.cpp
@@ -415,23 +415,25 @@ bool Proc::opt_cse(bool unsafeOpt)
         // we need to sanity check phis and post-doms
         bool bad = false;
         
-        // check post-dominator condition
-        for(int i = b0 ; i; i = blocks[i].idom)
+        // check post-dominator conditions, unless one block is ccd
+        if(b0 != ccd && b1 != ccd)
         {
-            // NOTE: DCE checks phis, so don't worry
-            if(ccd == blocks[i].idom) break; // this is fine
-            if(blocks[blocks[i].idom].pdom != i) bad = true;
-            if(bad) break;
-        }
-
-        // check post-dominator condition
-        if(!bad)
-        for(int i = b1; i; i = blocks[i].idom)
-        {
-            // NOTE: DCE checks phis, so don't worry
-            if(ccd == blocks[i].idom) break; // this is fine
-            if(blocks[blocks[i].idom].pdom != i) bad = true;
-            if(bad) break;
+            for(int i = b0 ; i; i = blocks[i].idom)
+            {
+                // NOTE: DCE checks phis, so don't worry
+                if(ccd == blocks[i].idom) break; // this is fine
+                if(blocks[blocks[i].idom].pdom != i) bad = true;
+                if(bad) break;
+            }
+    
+            if(!bad)
+            for(int i = b1; i; i = blocks[i].idom)
+            {
+                // NOTE: DCE checks phis, so don't worry
+                if(ccd == blocks[i].idom) break; // this is fine
+                if(blocks[blocks[i].idom].pdom != i) bad = true;
+                if(bad) break;
+            }
         }
 
         if(bad) { if(cse_debug) BJIT_LOG("BAD"); return false; }

--- a/src/opt-cse.cpp
+++ b/src/opt-cse.cpp
@@ -160,7 +160,7 @@ bool Proc::opt_cse(bool unsafeOpt)
                 //
                 // ignore this condition for ops with no inputs (ie. constants)
                 // since we can always rematerialize these cheap
-                if( blocks[blocks[mblock].idom].pdom != mblock)
+                if(op.nInputs() && blocks[blocks[mblock].idom].pdom != mblock)
                 {
                     if(blocks[mblock].comeFrom.size() > 1)
                     {

--- a/src/opt-cse.cpp
+++ b/src/opt-cse.cpp
@@ -136,6 +136,8 @@ bool Proc::opt_cse(bool unsafeOpt)
             // try to find a better block, but don't if we just sunk this
             // if this is not sunken and we hoist it into a branching block
             // then next SINK pass will break a critical edge for us
+            //
+            // don't bother if it's a constant
             if(!op.flags.no_opt) while(mblock)
             {
                 bool done = false;
@@ -158,7 +160,7 @@ bool Proc::opt_cse(bool unsafeOpt)
                 //
                 // ignore this condition for ops with no inputs (ie. constants)
                 // since we can always rematerialize these cheap
-                if(op.nInputs() && blocks[blocks[mblock].idom].pdom != mblock)
+                if( blocks[blocks[mblock].idom].pdom != mblock)
                 {
                     if(blocks[mblock].comeFrom.size() > 1)
                     {

--- a/src/opt-dce.cpp
+++ b/src/opt-dce.cpp
@@ -72,7 +72,7 @@ void Proc::opt_dce(bool unsafeOpt)
                         // cause problems with IV detection, which then hurts
                         // register allocation.. so just don't do it..
                         if(ops[i].opcode < ops::jmp
-                        && ops[kc[0]].opcode == ops::phi) break;
+                        && (kc[0] == noVal || ops[kc[0]].opcode == ops::phi)) break;
 
                         // skip over phis
                         for(int i = 0; i < kc.size(); ++i)

--- a/src/opt-jump.cpp
+++ b/src/opt-jump.cpp
@@ -421,7 +421,7 @@ bool Proc::opt_jump()
                     if(val.in[1] == a.phi)
                     {
                         // other operand must dominate PHI
-                        for(auto & d : blocks[b].dom)
+                        for(auto & d : blocks[blocks[b].idom].dom)
                         {
                             if(ops[val.in[0]].block != d) continue;
                             phi.iv = a.val;
@@ -432,7 +432,7 @@ bool Proc::opt_jump()
                     else if(val.in[0] == a.phi)
                     {
                         // other operand must dominate PHI
-                        for(auto & d : blocks[b].dom)
+                        for(auto & d : blocks[blocks[b].idom].dom)
                         {
                             if(ops[val.in[1]].block != d) continue;
                             phi.iv = a.val;

--- a/src/opt-jump.cpp
+++ b/src/opt-jump.cpp
@@ -336,6 +336,13 @@ bool Proc::opt_jump()
             continue;
         }
 
+        // if second branch is pdom, swap so DFS runs on loops first
+        if(op.opcode < ops::jmp && blocks[b].pdom == op.label[1])
+        {
+            op.opcode ^= 1;
+            std::swap(op.label[0], op.label[1]);
+        }
+
         if(op.flags.no_opt)
         {
             continue;

--- a/src/opt-ra.cpp
+++ b/src/opt-ra.cpp
@@ -69,6 +69,7 @@ void Proc::allocRegs(bool unsafeOpt)
             
             blocks[b].code[i] = newOp(ops::phi, op.flags.type, b);
             ops[blocks[b].code[i]].phiIndex = blocks[b].args.size();
+            ops[blocks[b].code[i]].iv = noVal;
             ops[blocks[b].code[i]].scc = op.scc;
             blocks[b].args.emplace_back(impl::Phi(blocks[b].code[i]));
 

--- a/src/opt-ra.cpp
+++ b/src/opt-ra.cpp
@@ -31,7 +31,7 @@ void Proc::allocRegs(bool unsafeOpt)
         todo.pop_back();
 
         auto & jmp = ops[blocks[b].code.back()];
-        
+
         if(jmp.opcode <= ops::jmp)
         for(int k = 0; k < 2; ++k)
         {
@@ -47,7 +47,6 @@ void Proc::allocRegs(bool unsafeOpt)
     }
 
     // rebuild the other stuff
-    rebuild_cfg();
     rebuild_dom();
     rebuild_livein();
 

--- a/src/opt-ra.cpp
+++ b/src/opt-ra.cpp
@@ -1438,6 +1438,8 @@ void Proc::findSCC()
         int nSCC = sccUsed.size();
         
         auto c = blocks[b].code.back();
+
+        auto p = blocks[b].code.size() - 1;
         
         if(ops[c].opcode <= ops::jmp)
         for(int k = 0; k < 2; ++k)
@@ -1458,8 +1460,8 @@ void Proc::findSCC()
                     ops[rr].scc = nSCC++;
                     ops[rr].in[0] = s.val; s.val = rr;
 
-                    std::swap(rr, blocks[b].code.back());
-                    blocks[b].code.push_back(rr);
+                    // this should usually result in a better order?
+                    blocks[b].code.insert(blocks[b].code.begin() + p, rr);
                 }
             }
         }


### PR DESCRIPTION
This now allows DCE to jump-thread simple jumps even through blocks with Phis, which allows some CFG simplifications (and perhaps even CSE?) that we previously couldn't handle. We don't allow this when the original jump is conditional though; this might be a little conservative(?), but if we destroy loop pre-headers, then we interfere with our simplistic IV detection and potentially LICM.

It also adds very simple induction variable (IV) detection with a simple hack for opt-ra to try to keep IVs in their original registers if possible (rename old value if still needed), which then makes it more likely we can avoid shuffles later at loop back-edges, which simplifies CFG at assembly.
